### PR TITLE
cli: Add a simple timemachine to reconstruct the network from msgs

### DIFF
--- a/cli/__main__.py
+++ b/cli/__main__.py
@@ -1,0 +1,13 @@
+import click
+from cli.timemachine import timemachine
+
+
+@click.group()
+def cli():
+    pass
+
+
+cli.add_command(timemachine)
+
+if __name__ == "__main__":
+    cli()

--- a/cli/common.py
+++ b/cli/common.py
@@ -1,0 +1,48 @@
+import click
+import bz2
+from pyln.proto.primitives import varint_decode
+from cli.parser import parse
+
+
+class DatasetStream:
+    def __init__(self, file_stream, decode=True):
+        self.stream = file_stream
+        self.decode = decode
+
+        # Read header
+        header = self.stream.read(4)
+        assert len(header) == 4
+        assert header[:3] == b"GSP"
+        assert header[3] == 1
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        pos = self.stream.tell()
+        length = varint_decode(self.stream)
+
+        if length is None:
+            raise StopIteration()
+
+        msg = self.stream.read(length)
+        if len(msg) != length:
+            raise ValueError(
+                "Error reading dataset at {pos}: incomplete read of {length} bytes, only got {mlen} bytes".format(
+                    pos=pos, length=length, mlen=len(msg)
+                )
+            )
+        if not self.decode:
+            return msg
+
+        return parse(msg)
+
+
+class DatasetFile(click.File):
+    def __init__(self, decode=True):
+        click.File.__init__(self)
+        self.decode = decode
+
+    def convert(self, value, param, ctx):
+        f = bz2.open(value, "rb") if value.endswith(".bz2") else open(value, "rb")
+        return DatasetStream(f, self.decode)

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -1,0 +1,267 @@
+from binascii import hexlify
+
+
+import io
+import struct
+
+
+class ChannelAnnouncement(object):
+    def __init__(self):
+        self.num_short_channel_id = None
+        self.node_signatures = [None, None]
+        self.bitcoin_signatures = [None, None]
+        self.features = None
+        self.chain_hash = None
+        self.node_ids = [None, None]
+        self.bitcoin_keys = [None, None]
+
+    @property
+    def short_channel_id(self):
+        return "{}x{}x{}".format(
+            (self.num_short_channel_id >> 40) & 0xFFFFFF,
+            (self.num_short_channel_id >> 16) & 0xFFFFFF,
+            (self.num_short_channel_id >> 00) & 0xFF,
+        )
+
+    def __eq__(self, other):
+        return (
+            self.num_short_channel_id == other.num_short_channel_id
+            and self.bitcoin_keys == other.bitcoin_keys
+            and self.chain_hash == other.chain_hash
+            and self.node_ids == other.node_ids
+            and self.features == other.features
+        )
+
+    def serialize(self):
+        raise ValueError()
+
+    def __str__(self):
+        na = hexlify(self.node_ids[0]).decode("ASCII")
+        nb = hexlify(self.node_ids[1]).decode("ASCII")
+        return "ChannelAnnouncement(scid={short_channel_id}, nodes=[{na},{nb}])".format(
+            na=na, nb=nb, short_channel_id=self.short_channel_id
+        )
+
+
+class ChannelUpdate(object):
+    def __init__(self):
+        self.signature = None
+        self.chain_hash = None
+        self.num_short_channel_id = None
+        self.timestamp = None
+        self.message_flags = None
+        self.channel_flags = None
+        self.cltv_expiry_delta = None
+        self.htlc_minimum_msat = None
+        self.fee_base_msat = None
+        self.fee_proportional_millionths = None
+        self.htlc_maximum_msat = None
+
+    @property
+    def short_channel_id(self):
+        return "{}x{}x{}".format(
+            (self.num_short_channel_id >> 40) & 0xFFFFFF,
+            (self.num_short_channel_id >> 16) & 0xFFFFFF,
+            (self.num_short_channel_id >> 00) & 0xFF,
+        )
+
+    @property
+    def direction(self):
+        (b,) = struct.unpack("!B", self.channel_flags)
+        return b & 0x01
+
+    def serialize(self):
+        raise ValueError()
+
+    def __str__(self):
+        return "ChannelUpdate(scid={short_channel_id}, timestamp={timestamp})".format(
+            timestamp=self.timestamp, short_channel_id=self.short_channel_id
+        )
+
+    def __eq__(self, other):
+        return (
+            self.chain_hash == other.chain_hash
+            and self.num_short_channel_id == other.num_short_channel_id
+            and self.timestamp == other.timestamp
+            and self.message_flags == other.message_flags
+            and self.channel_flags == other.channel_flags
+            and self.cltv_expiry_delta == other.cltv_expiry_delta
+            and self.htlc_minimum_msat == other.htlc_minimum_msat
+            and self.fee_base_msat == other.fee_base_msat
+            and self.fee_proportional_millionths == other.fee_proportional_millionths
+            and self.htlc_maximum_msat == other.htlc_maximum_msat
+        )
+
+
+class Address(object):
+    def __init__(self, typ=None, addr=None, port=None):
+        self.typ = typ
+        self.addr = addr
+        self.port = port
+
+    def __eq__(self, other):
+        return (
+            self.typ == other.typ
+            and self.addr == other.addr
+            and self.port == other.port
+        )
+
+    def __len__(self):
+        l = {
+            1: 6,
+            2: 18,
+            3: 12,
+            4: 37,
+        }
+        return l[self.typ] + 1
+
+    def __str__(self):
+        addr = self.addr
+        if self.typ == 1:
+            addr = ".".join([str(c) for c in addr])
+
+        protos = {
+            1: "ipv4",
+            2: "ipv6",
+            3: "torv2",
+            4: "torv3",
+        }
+
+        return f"{protos[self.typ]}://{addr}:{self.port}"
+
+
+class NodeAnnouncement(object):
+    def __init__(self):
+        self.signature = None
+        self.features = ""
+        self.timestamp = None
+        self.node_id = None
+        self.rgb_color = None
+        self.alias = None
+        self.addresses = None
+
+    def __str__(self):
+        return "NodeAnnouncement(id={hexlify(node_id)}, alias={alias}, color={rgb_color})".format(
+            node_id=self.node_id, alias=self.alias, rgb_color=self.rgb_color
+        )
+
+    def __eq__(self, other):
+        return (
+            self.features == other.features
+            and self.timestamp == other.timestamp
+            and self.node_id == other.node_id
+            and self.rgb_color == other.rgb_color
+            and self.alias == other.alias
+        )
+
+
+def parse(b):
+    if not isinstance(b, io.BytesIO):
+        b = io.BytesIO(b)
+    (typ,) = struct.unpack("!H", b.read(2))
+
+    parsers = {
+        256: parse_channel_announcement,
+        257: parse_node_announcement,
+        258: parse_channel_update,
+        3503: parse_ignore,
+    }
+
+    if typ not in parsers:
+        raise ValueError("No parser registered for type {typ}".format(typ=typ))
+
+    return parsers[typ](b)
+
+
+def parse_ignore(b):
+    return None
+
+
+def parse_channel_announcement(b):
+    if not isinstance(b, io.BytesIO):
+        b = io.BytesIO(b)
+
+    ca = ChannelAnnouncement()
+    ca.node_signatures = (b.read(64), b.read(64))
+    ca.bitcoin_signatures = (b.read(64), b.read(64))
+    (flen,) = struct.unpack("!H", b.read(2))
+    ca.features = b.read(flen)
+    ca.chain_hash = b.read(32)[::-1]
+    (ca.num_short_channel_id,) = struct.unpack("!Q", b.read(8))
+    ca.node_ids = (b.read(33), b.read(33))
+    ca.bitcoin_keys = (b.read(33), b.read(33))
+    return ca
+
+
+def parse_channel_update(b):
+    if not isinstance(b, io.BytesIO):
+        b = io.BytesIO(b)
+
+    cu = ChannelUpdate()
+    cu.signature = b.read(64)
+    cu.chain_hash = b.read(32)[::-1]
+    (cu.num_short_channel_id,) = struct.unpack("!Q", b.read(8))
+    (cu.timestamp,) = struct.unpack("!I", b.read(4))
+    cu.message_flags = b.read(1)
+    cu.channel_flags = b.read(1)
+    (cu.cltv_expiry_delta,) = struct.unpack("!H", b.read(2))
+    (cu.htlc_minimum_msat,) = struct.unpack("!Q", b.read(8))
+    (cu.fee_base_msat,) = struct.unpack("!I", b.read(4))
+    (cu.fee_proportional_millionths,) = struct.unpack("!I", b.read(4))
+    t = b.read(8)
+    if len(t) == 8:
+        (cu.htlc_maximum_msat,) = struct.unpack("!Q", t)
+    else:
+        cu.htlc_maximum_msat = None
+
+    return cu
+
+
+def parse_address(b):
+    if not isinstance(b, io.BytesIO):
+        b = io.BytesIO(b)
+
+    t = b.read(1)
+    if len(t) != 1:
+        return None
+
+    a = Address()
+    (a.typ,) = struct.unpack("!B", t)
+
+    if a.typ == 1:
+        a.addr = b.read(4)
+    elif a.typ == 2:
+        a.addr = b.read(16)
+    elif a.typ == 3:
+        a.addr = b.read(10)
+    elif a.typ == 4:
+        a.addr = b.read(35)
+    else:
+        raise ValueError("Unknown address type {typ}".format(typ=a.typ))
+    (a.port,) = struct.unpack("!H", b.read(2))
+    return a
+
+
+def parse_node_announcement(b):
+    if not isinstance(b, io.BytesIO):
+        b = io.BytesIO(b)
+
+    na = NodeAnnouncement()
+    na.signature = b.read(64)
+    (flen,) = struct.unpack("!H", b.read(2))
+    na.features = b.read(flen)
+    (na.timestamp,) = struct.unpack("!I", b.read(4))
+    na.node_id = b.read(33)
+    na.rgb_color = b.read(3)
+    na.alias = b.read(32)
+    (alen,) = struct.unpack("!H", b.read(2))
+    abytes = io.BytesIO(b.read(alen))
+    na.addresses = []
+    while True:
+        addr = parse_address(abytes)
+        if addr is None:
+            break
+        else:
+            na.addresses.append(addr)
+
+    return na

--- a/cli/timemachine.py
+++ b/cli/timemachine.py
@@ -1,0 +1,148 @@
+import sys
+import time
+from cli.common import DatasetFile
+import click
+import networkx as nx
+from cli.parser import ChannelAnnouncement, ChannelUpdate, NodeAnnouncement
+from tqdm import tqdm
+from datetime import datetime
+
+
+@click.group()
+def timemachine():
+    pass
+
+
+@timemachine.command()
+@click.argument("dataset", type=DatasetFile())
+@click.argument("timestamp", type=int, required=False)
+@click.option('--fmt', type=click.Choice(['dot', 'gml', 'graphml'], case_sensitive=False))
+def restore(dataset, timestamp=None, fmt='dot'):
+    """Restore reconstructs the network topology at a specific time in the past.
+
+    Restore replays gossip messages from a dataset and reconstructs
+    the network as it would have looked like at the specified
+    timestamp in the past. The network is then printed to stdout using
+    the format specified with `--fmt`.
+
+    """
+    if timestamp is None:
+        timestamp =    time.time()
+
+    cutoff = timestamp - 2 * 7 * 24 * 3600
+    channels = {}
+    nodes = {}
+
+    # Some target formats do not suport UTF-8 aliases.
+    codec = 'UTF-8' if fmt in ['dot'] else 'ASCII'
+
+    for m in tqdm(dataset, desc="Replaying gossip messages"):
+        if isinstance(m, ChannelAnnouncement):
+
+            channels[f"{m.short_channel_id}/0"] = {
+                "source": m.node_ids[0].hex(),
+                "destination": m.node_ids[1].hex(),
+                "timestamp": 0,
+                "features": m.features.hex(),
+            }
+
+            channels[f"{m.short_channel_id}/1"] = {
+                "source": m.node_ids[1].hex(),
+                "destination": m.node_ids[0].hex(),
+                "timestamp": 0,
+                "features": m.features.hex(),
+            }
+
+        elif isinstance(m, ChannelUpdate):
+            scid = f"{m.short_channel_id}/{m.direction}"
+            chan = channels.get(scid, None)
+            ts = m.timestamp
+
+            if ts > timestamp:
+                # Skip this update, it's in the future.
+                continue
+
+            if ts < cutoff:
+                # Skip updates that cannot possibly keep this channel alive
+                continue
+
+            if chan is None:
+                raise ValueError(
+                    f"Could not find channel with short_channel_id {scid}"
+                )
+
+            if chan["timestamp"] > ts:
+                # Skip this update, it's outdated.
+                continue
+
+            chan["timestamp"] = ts
+            chan["fee_base_msat"] = m.fee_base_msat
+            chan["fee_proportional_millionths"] = m.fee_proportional_millionths
+            chan["htlc_minimim_msat"] = m.htlc_minimum_msat
+            chan["htlc_maximum_msat"] = m.htlc_maximum_msat
+            chan["cltv_expiry_delta"] = m.cltv_expiry_delta
+        elif isinstance(m, NodeAnnouncement):
+            node_id = m.node_id.hex()
+
+            old = nodes.get(node_id, None)
+            if old is not None and old["timestamp"] > m.timestamp:
+                continue
+
+            alias = m.alias.replace(b'\x00', b'').decode(codec, 'ignore')
+            nodes[node_id] = {
+                "id": node_id,
+                "timestamp": m.timestamp,
+                "features": m.features.hex(),
+                "rgb_color": m.rgb_color.hex(),
+                "alias": alias,
+                "addresses": ",".join([str(a) for a in m.addresses]),
+                "out_degree": 0,
+                "in_degree": 0,
+            }
+
+    # Cleanup pass: drop channels that haven't seen an update in 2 weeks
+    todelete = []
+    for scid, chan in tqdm(channels.items(), desc="Pruning outdated channels"):
+        if chan["timestamp"] < cutoff:
+            todelete.append(scid)
+        else:
+            node = nodes.get(chan["source"], None)
+            if node is None:
+                continue
+            else:
+                node["out_degree"] += 1
+            node = nodes.get(chan["destination"], None)
+            if node is None:
+                continue
+            else:
+                node["in_degree"] += 1
+
+    for scid in todelete:
+        del channels[scid]
+
+    nodes = [n for n in nodes.values() if n["in_degree"] > 0 or n['out_degree'] > 0]
+
+    if len(channels) == 0:
+        print(
+            "ERROR: no channels are left after pruning, make sure to select a"
+            "timestamp that is covered by the dataset."
+        )
+        sys.exit(1)
+
+    g = nx.DiGraph()
+    for n in nodes:
+        g.add_node(n["id"], **n)
+
+    for scid, c in channels.items():
+        g.add_edge(c["source"], c["destination"], scid=scid, **c)
+
+    if fmt == 'dot':
+        print(nx.nx_pydot.to_pydot(g))
+
+    elif fmt == 'gml':
+        for line in nx.generate_gml(g):
+            print(line)
+
+    elif fmt == 'graphml':
+        for line in nx.generate_graphml(g):
+            print(line)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyln-proto==0.8.4
 click==7.1.2
 networkx==2.5
+pyln-proto==0.8.4
 tqdm==4.50.2

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,30 @@
+from setuptools import setup
+import io
+
+
+with io.open('README.org', encoding='utf-8') as f:
+    long_description = f.read()
+
+with io.open('requirements.txt', encoding='utf-8') as f:
+    requirements = [r for r in f.read().split('\n') if len(r)]
+
+setup(name='lntopo',
+      version='0.1.0',
+      description='Tools to work with lnresearch/topology datasets',
+      long_description=long_description,
+      long_description_content_type='text/x-org',
+      url='http://github.com/lnresearch/topology',
+      author='Christian Decker',
+      author_email='decker.christian@gmail.com',
+      license='MIT',
+      packages=[],
+      package_data={},
+      scripts=[],
+      zip_safe=True,
+      entry_points = {
+          'console_scripts': [
+              'lntopo-cli = cli.__main__:cli',
+          ],
+      },
+      install_requires=requirements
+)


### PR DESCRIPTION
We can replay the gossip messages in order and reconstruct the network as it
would have looked like at a specific time in the past. This tool does just that,
including the 2 weeks passive pruning logic (if a channel hasn't seen an update
in the last two weeks they are considered dead). It is not considering channel
closes that are signaled by spending the funding output, since that'd require
tracking the outputs.