### PR TITLE
Add JSON export support

### DIFF
--- a/lntopo/timemachine.py
+++ b/lntopo/timemachine.py
@@ -6,6 +6,8 @@ import networkx as nx
 from .parser import ChannelAnnouncement, ChannelUpdate, NodeAnnouncement
 from tqdm import tqdm
 from datetime import datetime
+import json
+from networkx.readwrite import json_graph
 
 
 @click.group()
@@ -16,7 +18,7 @@ def timemachine():
 @timemachine.command()
 @click.argument("dataset", type=DatasetFile())
 @click.argument("timestamp", type=int, required=False)
-@click.option('--fmt', type=click.Choice(['dot', 'gml', 'graphml'], case_sensitive=False))
+@click.option('--fmt', type=click.Choice(['dot', 'gml', 'graphml', 'json'], case_sensitive=False))
 def restore(dataset, timestamp=None, fmt='dot'):
     """Restore reconstructs the network topology at a specific time in the past.
 
@@ -147,3 +149,6 @@ def restore(dataset, timestamp=None, fmt='dot'):
     elif fmt == 'graphml':
         for line in nx.generate_graphml(g, named_key_ids=True, edge_id_from_attribute='scid'):
             print(line)
+
+    elif fmt == 'json':
+        print(json.dumps(json_graph.adjacency_data(g)))


### PR DESCRIPTION
This PR adds a new `json` value to the `timemachine restore` `--fmt` command option, allowing the user to output the graph in JSON format directly.

This is useful for programming languages with native JSON support like javascript, avoiding the use of 3rd party deps to parse currently supported output format, and offers better performance as well.

#### Example command:

```
lntopo-cli timemachine restore --fmt=json ~/Downloads/gossip-20210908.gsp 1521846000 > topology_1521846000
```

#### Example output (after formatting):

```json
{
  "directed": true,
  "multigraph": false,
  "graph": [],
  "nodes": [
    {
      "id": "02d97e94cfeedca2a3da47acb400bc6836e671b3cb3fc05bdd6993acd64483d09a",
      "timestamp": 1521331315,
      "features": "",
      "rgb_color": "3399ff",
      "alias": "02d97e94cfeedca2a3da",
      "addresses": "",
      "out_degree": 1,
      "in_degree": 0
    },
    {
      "id": "0246dae073f563308943c44f4d072f226f4968ea6a5a82079e9bfc9860a8a620f9",
      "timestamp": 1521812723,
      "features": "",
      "rgb_color": "f0a000",
      "alias": "pokatoo",
      "addresses": "ipv4://149.202.71.189:9735",
      "out_degree": 1,
      "in_degree": 0
    },
    {
      "id": "032c4b954f0f171b694b5e8e8323589e54196b48cf2efc27692513a360cb11d76f",
      "timestamp": 1599830749,
      "features": "",
      "rgb_color": "56a580",
      "alias": "nute.net",
      "addresses": "ipv4://79.137.115.56:9735",
      "out_degree": 0,
      "in_degree": 1
    },
    {
      "id": "03fab7f8655169ea77d9691d4bd359e97782cb6177a6f76383994ed9c262af97a5",
      "timestamp": 1620177588,
      "features": "0aa2a1",
      "rgb_color": "83b166",
      "alias": "webworker.sh",
      "addresses": "ipv4://158.69.255.49:9735",
      "out_degree": 0,
      "in_degree": 1
    }
  ],
  "adjacency": [
    [
      {
        "scid": "513887x1177x0/0",
        "source": "02d97e94cfeedca2a3da47acb400bc6836e671b3cb3fc05bdd6993acd64483d09a",
        "destination": "03fab7f8655169ea77d9691d4bd359e97782cb6177a6f76383994ed9c262af97a5",
        "timestamp": 1521522116,
        "features": "",
        "fee_base_msat": 1000,
        "fee_proportional_millionths": 1,
        "htlc_minimim_msat": 1000,
        "cltv_expiry_delta": 144,
        "id": "03fab7f8655169ea77d9691d4bd359e97782cb6177a6f76383994ed9c262af97a5"
      }
    ],
    [
      {
        "scid": "514798x115x0/0",
        "source": "0246dae073f563308943c44f4d072f226f4968ea6a5a82079e9bfc9860a8a620f9",
        "destination": "032c4b954f0f171b694b5e8e8323589e54196b48cf2efc27692513a360cb11d76f",
        "timestamp": 1521810524,
        "features": "",
        "fee_base_msat": 1000,
        "fee_proportional_millionths": 1,
        "htlc_minimim_msat": 1000,
        "cltv_expiry_delta": 144,
        "id": "032c4b954f0f171b694b5e8e8323589e54196b48cf2efc27692513a360cb11d76f"
      }
    ],
    [],
    []
  ]
}
```