### PR TITLE
Export node addresses in plain text instead of raw bytes

### DIFF
--- a/lntopo/parser.py
+++ b/lntopo/parser.py
@@ -270,15 +270,15 @@ def parse_address(b):
         (a.port,) = struct.unpack("!H", b.read(2))
     elif a.typ == 2:
         a.addr = b.read(16)
-        a.addr = format(ipaddress.IPv6Address(a.addr))
+        a.addr = '[' + format(ipaddress.IPv6Address(a.addr)) + ']'
         (a.port,) = struct.unpack("!H", b.read(2))
     elif a.typ == 3:
         a.addr = b.read(10)
-        a.addr = to_base_32(a.addr)
+        a.addr = to_base_32(a.addr) + '.onion'
         (a.port,) = struct.unpack("!H", b.read(2))
     elif a.typ == 4:
         a.addr = b.read(35)
-        a.addr = to_base_32(a.addr)
+        a.addr = to_base_32(a.addr) + '.onion'
         (a.port,) = struct.unpack("!H", b.read(2))
     else:
         a.addr = b.getvalue()[1:]


### PR DESCRIPTION
This PR modifies the output format for node addresses. Instead of exporting raw bytes, we encode them into human readable string.

Maybe this should be a feature toggled by an option flag.

Example output with graphml
```
    <node id="0213351211aecfd9688a1b5205d0949857f9349e4128b9f7dd8adf3c699207e494">
      <data key="d0">0213351211aecfd9688a1b5205d0949857f9349e4128b9f7dd8adf3c699207e494</data>
      <data key="d1">1524429955</data>
      <data key="d2" />
      <data key="d3">1551b2</data>
      <data key="d4">Murray Rothbard</data>
      <data key="d5">ipv4://46.101.51.48:9735</data>
      <data key="d6">0</data>
      <data key="d7">1</data>
    </node>
    <node id="027ccec61f4bf1fafb5156931da6527dc104ec3613dd4f4050161d89dd76ab494c">
      <data key="d0">027ccec61f4bf1fafb5156931da6527dc104ec3613dd4f4050161d89dd76ab494c</data>
      <data key="d1">1526724629</data>
      <data key="d2" />
      <data key="d3">ff5050</data>
      <data key="d4">heliacal</data>
      <data key="d5">ipv6://2001:470:5f:5f::232:9735</data>
      <data key="d6">0</data>
      <data key="d7">1</data>
    </node>
    <node id="02b66f6950d58aa6986ea50114d79d5ec798ed6c628964914d4e37f2abbeed0082">
      <data key="d0">02b66f6950d58aa6986ea50114d79d5ec798ed6c628964914d4e37f2abbeed0082</data>
      <data key="d1">1583584341</data>
      <data key="d2" />
      <data key="d3">68f442</data>
      <data key="d4">SPQR</data>
      <data key="d5">torv2://dhwxl6ozvsiat4zq:9735</data>
      <data key="d6">0</data>
      <data key="d7">1</data>
    </node>
    <node id="030bfda7ea0c5a6ebfc941e0ed34d7b2306000838d922877a4b8b1f21cb6dc3cc7">
      <data key="d0">030bfda7ea0c5a6ebfc941e0ed34d7b2306000838d922877a4b8b1f21cb6dc3cc7</data>
      <data key="d1">1585958513</data>
      <data key="d2">2200</data>
      <data key="d3">3399ff</data>
      <data key="d4">Oldschool</data>
      <data key="d5">torv3://itqwxmv5wi3w3szyfhgyufooykdvic5ehe45crdpw6d6ortdmcvzqfad:9735</data>
      <data key="d6">0</data>
      <data key="d7">3</data>
    </node>
```