### PR TITLE
timemachine: Add support for reconstruction/filtering of missing edges.

### DIFF
--- a/lntopo/timemachine.py
+++ b/lntopo/timemachine.py
@@ -144,7 +144,7 @@ def restore(dataset, timestamp=None, fmt='dot', fix_missing=None):
             else:
                 raise Exception("ERROR: unknown scid format.")
            
-           if opposite_scid not in channels:
+            if opposite_scid not in channels:
                 unmatched.append(scid)
 
         if fix_missing == "recover":

--- a/lntopo/timemachine.py
+++ b/lntopo/timemachine.py
@@ -160,7 +160,7 @@ def restore(dataset, timestamp=None, fmt='dot', fix_missing=None):
                 channels_cache = dict()
 
             os.makedirs(os.path.dirname(cache_file), exist_ok=True) 
-            with open(cache_file, 'w') as f:
+            with open(cache_file, 'a') as f:
                 for scid in tqdm(unmatched, desc="Attempting to recover missing edges"):
                     undirected_scid = scid[:-2]
                     if undirected_scid in channels_cache:

--- a/lntopo/timemachine.py
+++ b/lntopo/timemachine.py
@@ -154,7 +154,7 @@ def restore(dataset, timestamp=None, fmt='dot', fix_missing=None):
             # Attempt to recover missing edges
             if os.path.exists(cache_file) and os.stat(cache_file).st_size > 0:
                 with open(cache_file, 'r') as f:
-                    reader = csv.reader(f, quoting=csv.QUOTE_NONE)
+                    reader = csv.reader(f)
                     channels_cache = {rows[0]:json.loads(rows[1]) for rows in reader}
             else:
                 channels_cache = dict()

--- a/lntopo/timemachine.py
+++ b/lntopo/timemachine.py
@@ -210,10 +210,11 @@ def restore(dataset, timestamp=None, fmt='dot', fix_missing=None):
                             "destination": chan["source"],
                             "timestamp": chan["timestamp"],
                             "features": chan["features"],
-                            "fee_base_msat": recovered_data["fee_base_msat"],
-                            "fee_proportional_millionths": recovered_data["fee_rate_milli_msat"],
-                            "htlc_minimum_msat": recovered_data["min_htlc"],
-                            "cltv_expiry_delta": recovered_data["time_lock_delta"] }
+                            "fee_base_msat": int(recovered_data["fee_base_msat"]),
+                            "fee_proportional_millionths": int(recovered_data["fee_rate_milli_msat"]),
+                            "htlc_minimum_msat": int(recovered_data["min_htlc"]),
+                            "cltv_expiry_delta": int(recovered_data["time_lock_delta"]) 
+                            }
 
                         node = nodes.get(chan["destination"], None)
                         if node is None:


### PR DESCRIPTION
This PR implements optional correction of channels that only have data for one direction. It can be activated by setting parameter `--fix_missing` when building the graph, e.g.:

`python -m lntopo timemachine restore --fmt=gml --fix_missing=<filter/recover> <gsp.bz2 path> <timestamp> `

`filter` mode removes all channels for which a direction is missing. `recover` mode attempts to add the missing edges by retrieving data from the 1ML LN explorer. It removes channels for which no data is found. Both modes add a warning at the beginning of the output to inform how many channels were pruned. If no mode is set, the graph will build as in previous versions. 

Closes #18.